### PR TITLE
Use commonjs export

### DIFF
--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,4 +1,4 @@
-export default function () {
+module.exports = function () {
     return {
         noColors: true,
         <% if (errorDecorator) { %>
@@ -35,4 +35,4 @@ export default function () {
             throw new Error('Not implemented');
         }
     };
-}
+};


### PR DESCRIPTION
According to https://github.com/DevExpress/testcafe/issues/2304#issuecomment-380751412, plugin developers need to export their function as a commonjs module. Only when I changed this could I get `testcafe` to recognize my reporter.